### PR TITLE
Request to be scheduled for February 8, 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stijn Heldens (s.heldens@esciencecenter.nl)
 | Date | Presenter | Topic |
 |------|----------------|-------|
 | 2024-01-25 | Tim Besard (JuliaHub) | Introduction to GPU programming in Julia |
-| 2024-02-08 | TBD | TBD |
+| 2024-02-08 | Hanno Spreeuw | Porting the Python Source Extractor (PySE) to GPU without writing a single kernel |
 | 2024-02-22 | TBD | TBD |
 | 2024-03-07 | TBD | TBD |
 | 2024-03-21 | TBD | TBD |


### PR DESCRIPTION
This would be about my contributions to PADRE, which ends on December 31, 2023.

Fifteen year old Python code (PySE, Python Source Extractor) has been accelerated by a factor 20.

The last bottleneck for me to fix was the speedup of source measurements, Numba's guvectorize decorator was very effective in doing so. With the argument setting `target="cuda"` and the use of `cupyx` for connected component labeling, surprisingly we can deploy all workhorses within PySE on a GPU, such that we can also process much larger images (4K * 4K pixels) than the ones targeted for PADRE (2K * 2K) within one second.
All of this can be achieved without writing a single kernel.