### PR TITLE
Update session details for 20 November 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Contact persons:
 | 2025-09-25 | SIG | Updates and planning session |
 | 2025-10-09 | Henk Dreuning (SURF) | LUMI: One of Europe's fastest supercomputers |
 | 2025-11-06 | Alessio Sclocco and Stijn Heldens | HP2SIM: parallelizing a high-performance finite element toolbox in Julia |
-| 2025-11-20 | TBD | TBD |
+| 2025-11-20 | Elena Ranguelova? or Alessio Sclocco and Stijn Heldens | Nomenclature of our Computing technological expertise |
 | 2025-12-18 | Stijn Heldens | Introduction to Mixed-Precision GPU Programming |
 
 # 2024 Sessions


### PR DESCRIPTION
email from 30 October 2025:

Dear HPC SIG,

I have asked some of you, and a few have given their feedback (thanks!) on the   Technological Expertise Nomenclature I started a few weeks ago. Some motivation and ideas on how to use it can be found   here.

Could you, please, (especially if you haven’t done so before) have a look at the Computing part of the nomenclature and leave your comments in the relevant cells (please, don’t edit the cells themselves)?

A specific question I have is, how to name the “Accelerated computing” category? In the last Skills survey, there are two overlapping (or rather one is a subset of the other) names, “Accelerated computing” and “GPU computing”, and I prefer not to have overlaps if that can be avoided 😉: •	How shall we cover this expertise- just “Accelerated computing”; “AC” with GPU, DPU, etc. In brackets after; separate categories for “GPU computing” , “DPU computing”, etc. (which ones?); other?

Thanks!
Elena